### PR TITLE
Add dedicated About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>About — Rachael Tutwiler Fortune</title>
+  <meta name="description" content="Learn more about Rachael Tutwiler Fortune, a bridge-builder who equips leaders across sectors with courage, clarity, and care." />
+  <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header class="site-header">
+    <div class="container nav">
+      <a class="brand" href="index.html#home" aria-label="Rachael Tutwiler Fortune home">
+        <img src="assets/logo.svg" alt="" width="28" height="28" aria-hidden="true">
+        <span>Rachael Tutwiler Fortune</span>
+      </a>
+      <button class="menu-btn" aria-expanded="false" aria-controls="nav-list" aria-label="Menu">☰</button>
+      <nav id="nav-list" class="nav-list" aria-label="Main">
+        <a href="about.html" aria-current="page">About</a>
+        <a href="index.html#book">Book</a>
+        <a href="index.html#speaking">Speaking</a>
+        <a href="index.html#testimonials">Testimonials</a>
+        <a href="index.html#contact" class="btn btn-accent">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="section">
+      <div class="container">
+        <header class="section-header">
+          <h1>Meet Rachael — a nationally recognized leader dedicated to creating opportunity for every child and equipping leaders in every sector to build bridges in times of change.</h1>
+        </header>
+
+        <article class="bio card">
+          <p><strong>Rachael Tutwiler Fortune</strong> is a nationally recognized leader and bridge‑builder who equips people and organizations to lead with courage, clarity, and care. She is best known for mobilizing partners to create opportunity for every child, while offering lessons that resonate with leaders across business, nonprofit, education, and civic life.</p>
+          <p>As President of the Jacksonville Public Education Fund, Rachael has brought together educators, families, business leaders, and philanthropists to drive meaningful results for students and the broader community. She is also an Adjunct Instructor of Leadership at the University of North Florida and a proud graduate of both Stanford University and UNF.</p>
+          <p>An award‑winning leader, Rachael has served in national and local leadership roles and lends her expertise across boards in health, education, and civic engagement. Her work centers on practical, people‑first leadership that bridges divides and inspires lasting impact. She champions <em>Heal. Think. Lead.</em> — a simple, powerful framework that helps leaders restore trust, focus on what matters, and act with integrity.</p>
+          <p>Whether in a classroom, boardroom, or community forum, Rachael helps people see challenges as opportunities to build bridges — so every generation can thrive.</p>
+          <ul class="highlights">
+            <li>Educator & Non‑Profit Executive</li>
+            <li>Advocate for opportunity for every child</li>
+            <li>Collaborative, data‑informed leader</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-grid">
+      <nav aria-label="Footer">
+        <a href="index.html#home">Home</a>
+        <a href="about.html" aria-current="page">About</a>
+        <a href="index.html#book">Book</a>
+        <a href="index.html#speaking">Speaking</a>
+        <a href="index.html#testimonials">Testimonials</a>
+        <a href="index.html#contact">Contact</a>
+      </nav>
+      <p class="copyright">© <span id="year"></span> Rachael Tutwiler Fortune. All rights reserved.</p>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       </a>
       <button class="menu-btn" aria-expanded="false" aria-controls="nav-list" aria-label="Menu">☰</button>
       <nav id="nav-list" class="nav-list" aria-label="Main">
-        <a href="#about">About</a>
+        <a href="about.html">About</a>
         <a href="#book">Book</a>
         <a href="#speaking">Speaking</a>
         <a href="#testimonials">Testimonials</a>
@@ -45,27 +45,6 @@
       </div>
     </section>
 
-    <!-- About -->
-    <section id="about" class="section">
-      <div class="container">
-        <header class="section-header">
-          <h2>About</h2>
-          <p class="kicker">Meet Rachael — a nationally recognized leader dedicated to creating opportunity for every child and equipping leaders in every sector to build bridges in times of change.</p>
-        </header>
-
-        <article class="bio card">
-          <p><strong>Rachael Tutwiler Fortune</strong> is a nationally recognized leader and bridge‑builder who equips people and organizations to lead with courage, clarity, and care. She is best known for mobilizing partners to create opportunity for every child, while offering lessons that resonate with leaders across business, nonprofit, education, and civic life.</p>
-          <p>As President of the Jacksonville Public Education Fund, Rachael has brought together educators, families, business leaders, and philanthropists to drive meaningful results for students and the broader community. She is also an Adjunct Instructor of Leadership at the University of North Florida and a proud graduate of both Stanford University and UNF.</p>
-          <p>An award‑winning leader, Rachael has served in national and local leadership roles and lends her expertise across boards in health, education, and civic engagement. Her work centers on practical, people‑first leadership that bridges divides and inspires lasting impact. She champions <em>Heal. Think. Lead.</em> — a simple, powerful framework that helps leaders restore trust, focus on what matters, and act with integrity.</p>
-          <p>Whether in a classroom, boardroom, or community forum, Rachael helps people see challenges as opportunities to build bridges — so every generation can thrive.</p>
-          <ul class="highlights">
-            <li>Educator & Non‑Profit Executive</li>
-            <li>Advocate for opportunity for every child</li>
-            <li>Collaborative, data‑informed leader</li>
-          </ul>
-        </article>
-      </div>
-    </section>
 
     <!-- Book -->
     <section id="book" class="section alt">
@@ -188,7 +167,7 @@
     <div class="container footer-grid">
       <nav aria-label="Footer">
         <a href="#home">Home</a>
-        <a href="#about">About</a>
+        <a href="about.html">About</a>
         <a href="#book">Book</a>
         <a href="#speaking">Speaking</a>
         <a href="#testimonials">Testimonials</a>


### PR DESCRIPTION
## Summary
- create standalone About page with full biography
- point navigation to the new page and remove embedded About section from the homepage

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b091a26e20832ea512f2dd01746207