### PR TITLE
Add dedicated book page and update navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -19,7 +19,7 @@
       <button class="menu-btn" aria-expanded="false" aria-controls="nav-list" aria-label="Menu">☰</button>
       <nav id="nav-list" class="nav-list" aria-label="Main">
         <a href="about.html" aria-current="page">About</a>
-        <a href="index.html#book">Book</a>
+        <a href="book.html">Book</a>
         <a href="index.html#speaking">Speaking</a>
         <a href="index.html#testimonials">Testimonials</a>
         <a href="index.html#contact" class="btn btn-accent">Contact</a>
@@ -54,7 +54,7 @@
       <nav aria-label="Footer">
         <a href="index.html#home">Home</a>
         <a href="about.html" aria-current="page">About</a>
-        <a href="index.html#book">Book</a>
+        <a href="book.html">Book</a>
         <a href="index.html#speaking">Speaking</a>
         <a href="index.html#testimonials">Testimonials</a>
         <a href="index.html#contact">Contact</a>

--- a/book.html
+++ b/book.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Book — Rachael Tutwiler Fortune</title>
+  <meta name="description" content="Bridge Builder equips leaders to heal, think, and lead with courage and care." />
+  <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header class="site-header">
+    <div class="container nav">
+      <a class="brand" href="index.html#home" aria-label="Rachael Tutwiler Fortune home">
+        <img src="assets/logo.svg" alt="" width="28" height="28" aria-hidden="true">
+        <span>Rachael Tutwiler Fortune</span>
+      </a>
+      <button class="menu-btn" aria-expanded="false" aria-controls="nav-list" aria-label="Menu">☰</button>
+      <nav id="nav-list" class="nav-list" aria-label="Main">
+        <a href="about.html">About</a>
+        <a href="book.html" aria-current="page">Book</a>
+        <a href="index.html#speaking">Speaking</a>
+        <a href="index.html#testimonials">Testimonials</a>
+        <a href="index.html#contact" class="btn btn-accent">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <section id="book" class="section alt">
+      <div class="container grid-2">
+        <div class="book-media">
+          <img src="assets/book-cover.svg" alt="Book cover: Bridge Builder" />
+        </div>
+        <div class="book-copy">
+          <h1><span class="soft">Book</span><br>Bridge Builder: Leading with Purpose and Courage to Create Opportunity for All</h1>
+          <p class="tagline">A leadership memoir and playbook for anyone tasked with building bridges in a divided world.</p>
+          <p>Part story, part playbook, <em>Bridge Builder</em> equips leaders at every level to transform how they show up — for themselves, their teams, and their communities. Rooted in her journey through education and civic leadership, Rachael shares her <em>Heal. Think. Lead.</em> framework, offering practical strategies, reflective prompts, and real‑world lessons that apply across sectors.</p>
+          <div class="actions">
+            <a href="index.html#contact" class="btn">Preorder Interest</a>
+            <a href="assets/sample.pdf" class="btn btn-outline">Read a Sample</a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-grid">
+      <nav aria-label="Footer">
+        <a href="index.html#home">Home</a>
+        <a href="about.html">About</a>
+        <a href="book.html" aria-current="page">Book</a>
+        <a href="index.html#speaking">Speaking</a>
+        <a href="index.html#testimonials">Testimonials</a>
+        <a href="index.html#contact">Contact</a>
+      </nav>
+      <p class="copyright">© <span id="year"></span> Rachael Tutwiler Fortune. All rights reserved.</p>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
       <button class="menu-btn" aria-expanded="false" aria-controls="nav-list" aria-label="Menu">☰</button>
       <nav id="nav-list" class="nav-list" aria-label="Main">
         <a href="about.html">About</a>
-        <a href="#book">Book</a>
+        <a href="book.html">Book</a>
         <a href="#speaking">Speaking</a>
         <a href="#testimonials">Testimonials</a>
         <a href="#contact" class="btn btn-accent">Contact</a>
@@ -35,31 +35,12 @@
           <h1>Bridge‑builder. Educator. Author. Speaker.</h1>
           <p class="subhead">Rachael Tutwiler Fortune inspires leaders across sectors to heal what’s broken, think with clarity, and lead with courage and care.</p>
           <div class="actions">
-            <a href="#book" class="btn">Explore the Book</a>
+            <a href="book.html" class="btn">Explore the Book</a>
             <a href="#contact" class="btn btn-accent">Invite Rachael to Speak</a>
           </div>
         </div>
         <div class="hero-media">
           <img src="assets/portrait.svg" alt="Portrait of Rachael Tutwiler Fortune" />
-        </div>
-      </div>
-    </section>
-
-
-    <!-- Book -->
-    <section id="book" class="section alt">
-      <div class="container grid-2">
-        <div class="book-media">
-          <img src="assets/book-cover.svg" alt="Book cover: Bridge Builder" />
-        </div>
-        <div class="book-copy">
-          <h2><span class="soft">Book</span><br>Bridge Builder: Leading with Purpose and Courage to Create Opportunity for All</h2>
-          <p class="tagline">A leadership memoir and playbook for anyone tasked with building bridges in a divided world.</p>
-          <p>Part story, part playbook, <em>Bridge Builder</em> equips leaders at every level to transform how they show up — for themselves, their teams, and their communities. Rooted in her journey through education and civic leadership, Rachael shares her <em>Heal. Think. Lead.</em> framework, offering practical strategies, reflective prompts, and real‑world lessons that apply across sectors.</p>
-          <div class="actions">
-            <a href="#contact" class="btn">Preorder Interest</a>
-            <a href="assets/sample.pdf" class="btn btn-outline">Read a Sample</a>
-          </div>
         </div>
       </div>
     </section>
@@ -168,7 +149,7 @@
       <nav aria-label="Footer">
         <a href="#home">Home</a>
         <a href="about.html">About</a>
-        <a href="#book">Book</a>
+        <a href="book.html">Book</a>
         <a href="#speaking">Speaking</a>
         <a href="#testimonials">Testimonials</a>
         <a href="#contact">Contact</a>


### PR DESCRIPTION
## Summary
- Introduce standalone book page describing *Bridge Builder* with sample and preorder links.
- Update header, footer, and hero button to point to the new book page and remove book section from home.
- Adjust about page navigation to reference the book page.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b095279194832eb06637390db5cad3