### PR TITLE
Add RTF photo to main and about pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -35,6 +35,7 @@
         </header>
 
         <article class="bio card">
+          <img src="RTF.jpg" alt="Rachael Tutwiler Fortune" class="bio-photo">
           <p><strong>Rachael Tutwiler Fortune</strong> is a nationally recognized leader and bridge‑builder who equips people and organizations to lead with courage, clarity, and care. She is best known for mobilizing partners to create opportunity for every child, while offering lessons that resonate with leaders across business, nonprofit, education, and civic life.</p>
           <p>As President of the Jacksonville Public Education Fund, Rachael has brought together educators, families, business leaders, and philanthropists to drive meaningful results for students and the broader community. She is also an Adjunct Instructor of Leadership at the University of North Florida and a proud graduate of both Stanford University and UNF.</p>
           <p>An award‑winning leader, Rachael has served in national and local leadership roles and lends her expertise across boards in health, education, and civic engagement. Her work centers on practical, people‑first leadership that bridges divides and inspires lasting impact. She champions <em>Heal. Think. Lead.</em> — a simple, powerful framework that helps leaders restore trust, focus on what matters, and act with integrity.</p>

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
           </div>
         </div>
         <div class="hero-media">
-          <img src="assets/portrait.svg" alt="Portrait of Rachael Tutwiler Fortune" />
+          <img src="RTF.jpg" alt="Portrait of Rachael Tutwiler Fortune" />
         </div>
       </div>
     </section>

--- a/styles.css
+++ b/styles.css
@@ -56,6 +56,7 @@ body{
 .hero h1{font-size:clamp(28px,4vw,44px);line-height:1.1;margin:.25rem 0 .75rem 0}
 .subhead{font-size:clamp(16px,2.2vw,20px);max-width:60ch}
 .hero-media img{width:min(420px,100%);height:auto;border-radius:var(--radius);box-shadow:var(--shadow)}
+.bio-photo{width:min(420px,100%);height:auto;border-radius:var(--radius);box-shadow:var(--shadow);display:block;margin:0 auto 1rem}
 .actions{display:flex;gap:.75rem;margin-top:1rem;flex-wrap:wrap}
 
 /* Grids */


### PR DESCRIPTION
## Summary
- Display Rachael Tutwiler Fortune's photo on the home page hero area.
- Introduce her photo on the About page with dedicated styling.
- Add new CSS class for consistent photo presentation.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b09666d8d4832ea8c07295ea442205