### PR TITLE
Move about page photo before heading

### DIFF
--- a/about.html
+++ b/about.html
@@ -30,12 +30,11 @@
   <main id="main">
     <section class="section">
       <div class="container">
-        <header class="section-header">
-          <h1>Meet Rachael — a nationally recognized leader dedicated to creating opportunity for every child and equipping leaders in every sector to build bridges in times of change.</h1>
-        </header>
-
         <article class="bio card">
           <img src="RTF.jpg" alt="Rachael Tutwiler Fortune" class="bio-photo">
+          <header class="section-header">
+            <h1>Meet Rachael — a nationally recognized leader dedicated to creating opportunity for every child and equipping leaders in every sector to build bridges in times of change.</h1>
+          </header>
           <p><strong>Rachael Tutwiler Fortune</strong> is a nationally recognized leader and bridge‑builder who equips people and organizations to lead with courage, clarity, and care. She is best known for mobilizing partners to create opportunity for every child, while offering lessons that resonate with leaders across business, nonprofit, education, and civic life.</p>
           <p>As President of the Jacksonville Public Education Fund, Rachael has brought together educators, families, business leaders, and philanthropists to drive meaningful results for students and the broader community. She is also an Adjunct Instructor of Leadership at the University of North Florida and a proud graduate of both Stanford University and UNF.</p>
           <p>An award‑winning leader, Rachael has served in national and local leadership roles and lends her expertise across boards in health, education, and civic engagement. Her work centers on practical, people‑first leadership that bridges divides and inspires lasting impact. She champions <em>Heal. Think. Lead.</em> — a simple, powerful framework that helps leaders restore trust, focus on what matters, and act with integrity.</p>


### PR DESCRIPTION
## Summary
- Show Rachael's photo above the "Meet Rachael" heading on the about page

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/RTFWebsite/package.json')*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0978dd6f8832e98eb4389b635ae39