### PR TITLE
Add combined speaking page and link to About

### DIFF
--- a/about.html
+++ b/about.html
@@ -20,8 +20,7 @@
       <nav id="nav-list" class="nav-list" aria-label="Main">
         <a href="about.html" aria-current="page">About</a>
         <a href="book.html">Book</a>
-        <a href="index.html#speaking">Speaking</a>
-        <a href="index.html#testimonials">Testimonials</a>
+        <a href="speaking.html">Speaking</a>
         <a href="index.html#contact" class="btn btn-accent">Contact</a>
       </nav>
     </div>
@@ -55,8 +54,7 @@
         <a href="index.html#home">Home</a>
         <a href="about.html" aria-current="page">About</a>
         <a href="book.html">Book</a>
-        <a href="index.html#speaking">Speaking</a>
-        <a href="index.html#testimonials">Testimonials</a>
+        <a href="speaking.html">Speaking</a>
         <a href="index.html#contact">Contact</a>
       </nav>
       <p class="copyright">© <span id="year"></span> Rachael Tutwiler Fortune. All rights reserved.</p>

--- a/book.html
+++ b/book.html
@@ -20,8 +20,7 @@
       <nav id="nav-list" class="nav-list" aria-label="Main">
         <a href="about.html">About</a>
         <a href="book.html" aria-current="page">Book</a>
-        <a href="index.html#speaking">Speaking</a>
-        <a href="index.html#testimonials">Testimonials</a>
+        <a href="speaking.html">Speaking</a>
         <a href="index.html#contact" class="btn btn-accent">Contact</a>
       </nav>
     </div>
@@ -52,8 +51,7 @@
         <a href="index.html#home">Home</a>
         <a href="about.html">About</a>
         <a href="book.html" aria-current="page">Book</a>
-        <a href="index.html#speaking">Speaking</a>
-        <a href="index.html#testimonials">Testimonials</a>
+        <a href="speaking.html">Speaking</a>
         <a href="index.html#contact">Contact</a>
       </nav>
       <p class="copyright">© <span id="year"></span> Rachael Tutwiler Fortune. All rights reserved.</p>

--- a/index.html
+++ b/index.html
@@ -20,8 +20,7 @@
       <nav id="nav-list" class="nav-list" aria-label="Main">
         <a href="about.html">About</a>
         <a href="book.html">Book</a>
-        <a href="#speaking">Speaking</a>
-        <a href="#testimonials">Testimonials</a>
+        <a href="speaking.html">Speaking</a>
         <a href="#contact" class="btn btn-accent">Contact</a>
       </nav>
     </div>
@@ -45,73 +44,13 @@
       </div>
     </section>
 
-    <!-- Speaking -->
-    <section id="speaking" class="section">
+    <!-- About Link -->
+    <section id="about-link" class="section">
       <div class="container">
-        <header class="section-header">
-          <h2>Speaking</h2>
-          <p class="kicker">From boardrooms to classrooms, Rachael delivers keynotes, panels, and workshops that inspire and equip audiences to lead with courage and clarity.</p>
-        </header>
-        <div class="topics grid-3">
-          <div class="card">
-            <h3>Heal. Think. Lead.</h3>
-            <p>Practical strategies for restoring trust, focusing on what matters, and catalyzing results.</p>
-          </div>
-          <div class="card">
-            <h3>Bridging Divides</h3>
-            <p>How to align perspectives, convene allies, and drive impact across communities and organizations.</p>
-          </div>
-          <div class="card">
-            <h3>A Vision for Students’ Future</h3>
-            <p>Inspiring communities to imagine what’s possible for the next generation and what it will take across sectors to prepare them.</p>
-          </div>
-        </div>
-
-        <form id="request-form" class="form card" aria-labelledby="request-heading">
-          <h3 id="request-heading">Request Rachael for Your Event</h3>
-          <div class="form-grid">
-            <label>Full Name
-              <input name="name" type="text" required autocomplete="name" />
-            </label>
-            <label>Organization
-              <input name="org" type="text" autocomplete="organization" />
-            </label>
-            <label>Email
-              <input name="email" type="email" required autocomplete="email" />
-            </label>
-            <label>Event Date
-              <input name="date" type="date" />
-            </label>
-            <label class="full">Details
-              <textarea name="details" rows="5" placeholder="Tell us about your audience, goals, and preferred topics."></textarea>
-            </label>
-          </div>
-          <button type="submit" class="btn btn-accent">Send Request</button>
-          <p class="form-note">This static form will open your email client with a pre‑filled message to <a href="mailto:info@rachaeltfortune.com">info@rachaeltfortune.com</a>.</p>
-        </form>
-      </div>
-    </section>
-
-    <!-- Testimonials -->
-    <section id="testimonials" class="section alt">
-      <div class="container">
-        <header class="section-header">
-          <h2>Praise for Rachael</h2>
-        </header>
-        <div class="testimonials grid-3">
-          <blockquote class="card">
-            <p>“Insert quote from event organizer here.”</p>
-            <cite>— Event Organizer</cite>
-          </blockquote>
-          <blockquote class="card">
-            <p>“Insert quote from business or civic leader here.”</p>
-            <cite>— Business/Civic Leader</cite>
-          </blockquote>
-          <blockquote class="card">
-            <p>“Insert quote from educator or student here.”</p>
-            <cite>— Educator or Student</cite>
-          </blockquote>
-        </div>
+        <a href="about.html" class="card">
+          <h3>About Me</h3>
+          <p>Learn more about Rachael’s journey and mission.</p>
+        </a>
       </div>
     </section>
 
@@ -150,8 +89,7 @@
         <a href="#home">Home</a>
         <a href="about.html">About</a>
         <a href="book.html">Book</a>
-        <a href="#speaking">Speaking</a>
-        <a href="#testimonials">Testimonials</a>
+        <a href="speaking.html">Speaking</a>
         <a href="#contact">Contact</a>
       </nav>
       <p class="copyright">© <span id="year"></span> Rachael Tutwiler Fortune. All rights reserved.</p>

--- a/speaking.html
+++ b/speaking.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Speaking — Rachael Tutwiler Fortune</title>
+  <meta name="description" content="Explore speaking topics, request Rachael for your event, and read testimonials." />
+  <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header class="site-header">
+    <div class="container nav">
+      <a class="brand" href="index.html#home" aria-label="Rachael Tutwiler Fortune home">
+        <img src="assets/logo.svg" alt="" width="28" height="28" aria-hidden="true">
+        <span>Rachael Tutwiler Fortune</span>
+      </a>
+      <button class="menu-btn" aria-expanded="false" aria-controls="nav-list" aria-label="Menu">☰</button>
+      <nav id="nav-list" class="nav-list" aria-label="Main">
+        <a href="about.html">About</a>
+        <a href="book.html">Book</a>
+        <a href="speaking.html" aria-current="page">Speaking</a>
+        <a href="index.html#contact" class="btn btn-accent">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <!-- Speaking -->
+    <section id="speaking" class="section">
+      <div class="container">
+        <header class="section-header">
+          <h2>Speaking</h2>
+          <p class="kicker">From boardrooms to classrooms, Rachael delivers keynotes, panels, and workshops that inspire and equip audiences to lead with courage and clarity.</p>
+        </header>
+        <div class="topics grid-3">
+          <div class="card">
+            <h3>Heal. Think. Lead.</h3>
+            <p>Practical strategies for restoring trust, focusing on what matters, and catalyzing results.</p>
+          </div>
+          <div class="card">
+            <h3>Bridging Divides</h3>
+            <p>How to align perspectives, convene allies, and drive impact across communities and organizations.</p>
+          </div>
+          <div class="card">
+            <h3>A Vision for Students’ Future</h3>
+            <p>Inspiring communities to imagine what’s possible for the next generation and what it will take across sectors to prepare them.</p>
+          </div>
+        </div>
+
+        <form id="request-form" class="form card" aria-labelledby="request-heading">
+          <h3 id="request-heading">Request Rachael for Your Event</h3>
+          <div class="form-grid">
+            <label>Full Name
+              <input name="name" type="text" required autocomplete="name" />
+            </label>
+            <label>Organization
+              <input name="org" type="text" autocomplete="organization" />
+            </label>
+            <label>Email
+              <input name="email" type="email" required autocomplete="email" />
+            </label>
+            <label>Event Date
+              <input name="date" type="date" />
+            </label>
+            <label class="full">Details
+              <textarea name="details" rows="5" placeholder="Tell us about your audience, goals, and preferred topics."></textarea>
+            </label>
+          </div>
+          <button type="submit" class="btn btn-accent">Send Request</button>
+          <p class="form-note">This static form will open your email client with a pre‑filled message to <a href="mailto:info@rachaeltfortune.com">info@rachaeltfortune.com</a>.</p>
+        </form>
+      </div>
+    </section>
+
+    <!-- Testimonials -->
+    <section id="testimonials" class="section alt">
+      <div class="container">
+        <header class="section-header">
+          <h2>Praise for Rachael</h2>
+        </header>
+        <div class="testimonials grid-3">
+          <blockquote class="card">
+            <p>“Insert quote from event organizer here.”</p>
+            <cite>— Event Organizer</cite>
+          </blockquote>
+          <blockquote class="card">
+            <p>“Insert quote from business or civic leader here.”</p>
+            <cite>— Business/Civic Leader</cite>
+          </blockquote>
+          <blockquote class="card">
+            <p>“Insert quote from educator or student here.”</p>
+            <cite>— Educator or Student</cite>
+          </blockquote>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-grid">
+      <nav aria-label="Footer">
+        <a href="index.html#home">Home</a>
+        <a href="about.html">About</a>
+        <a href="book.html">Book</a>
+        <a href="speaking.html" aria-current="page">Speaking</a>
+        <a href="index.html#contact">Contact</a>
+      </nav>
+      <p class="copyright">© <span id="year"></span> Rachael Tutwiler Fortune. All rights reserved.</p>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -68,7 +68,7 @@ body{
 }
 
 /* Cards, buttons */
-.card{background:#fff;border:1px solid #eee;border-radius:var(--radius);padding:clamp(16px,2vw,24px);box-shadow:var(--shadow)}
+.card{display:block;background:#fff;border:1px solid #eee;border-radius:var(--radius);padding:clamp(16px,2vw,24px);box-shadow:var(--shadow);text-decoration:none;color:inherit}
 .btn{display:inline-block;background:var(--teal);color:#fff;text-decoration:none;border:0;border-radius:.8rem;padding:.7rem 1rem;font-weight:600}
 .btn:hover{opacity:.92}
 .btn-accent{background:var(--coral)}


### PR DESCRIPTION
## Summary
- move speaking topics and testimonials to new `speaking.html`
- update navigation across site to link to combined speaking page
- add About Me card on homepage and allow cards to function as links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0993c2d30832eb804ca745382a2a5